### PR TITLE
Fix derived types in gcov file

### DIFF
--- a/grammars/fortran-free-form-gcov.cson
+++ b/grammars/fortran-free-form-gcov.cson
@@ -17,6 +17,13 @@ patterns: [
   {include: 'source.fortran.free'}
 ]
 repository: {
+  # This pattern is customized so a couple of "end type" regexes aren't
+  # anchored to the start of a line. A much more general fix would be to
+  # find a way for the GCOV markup added to the front of the line to be
+  # "ignored" by all of the included patterns and skipped over as if it wasn't
+  # even there. I don't think this is possible using the CSON grammar syntax
+  # but may work using the new tree-sitter logic since I think I could just
+  # call it an "extra".
   'derived-type-definition':
     'name': 'meta.derived-type.definition.fortran'
     'begin': '(?i)\\b(type)\\b(?!\\s*(\\(|is\\b|\\=))'
@@ -38,11 +45,7 @@ repository: {
               '1': 'name': 'punctuation.comma.fortran'
             'end': '(?=::|[,;!\\n])'
             'patterns':[
-              {'include': '#access-attribute'}
-              {'include': '#abstract-attribute'}
-              {'include': '#language-binding-attribute'}
-              {'include': '#extends-attribute'}
-              {'include': '#invalid-word'}
+              {'include': '$self'}
             ]
           }
         ]
@@ -67,11 +70,7 @@ repository: {
             #'begin': '(?i)^(?!\\s*\\b(?:contains|end\\s*type)\\b)'
             #'end': '(?i)^(?=\\s*\\b(?:contains|end\\s*type)\\b)'
             'patterns':[
-              {'include': '#comments'}
-              {'include': '#derived-type-component-attribute-specification'}
-              {'include': '#derived-type-component-parameter-specification'}
-              {'include': '#derived-type-component-procedure-specification'}
-              {'include': '#derived-type-component-type-specification'}
+              {'include': '$self'}
             ]
           }
           {# contains section
@@ -82,11 +81,7 @@ repository: {
               '1': 'name': 'keyword.control.contains.fortran'
             'end': '(?i)(?=\\s*end\\s*type\\b)'
             'patterns':[
-              {'include': '#comments'}
-              {'include': '#derived-type-contains-attribute-specification'}
-              {'include': '#derived-type-contains-final-procedure-specification'}
-              {'include': '#derived-type-contains-generic-procedure-specification'}
-              {'include': '#derived-type-contains-procedure-specification'}
+              {'include': '$self'}
             ]
           }
         ]

--- a/grammars/fortran-free-form-gcov.cson
+++ b/grammars/fortran-free-form-gcov.cson
@@ -12,6 +12,84 @@ fileTypes: [
   'F08.gcov'
 ]
 patterns: [
+  {include: '#derived-type-definition'}
   {include: 'source.gcov'}
   {include: 'source.fortran.free'}
 ]
+repository: {
+  'derived-type-definition':
+    'name': 'meta.derived-type.definition.fortran'
+    'begin': '(?i)\\b(type)\\b(?!\\s*(\\(|is\\b|\\=))'
+    'beginCaptures':
+      '1': 'name': 'keyword.control.type.fortran'
+    'end': '(?=[;!\\n])'
+    'patterns': [
+      {
+        'comment': 'Attribute list.'
+        'contentName': 'meta.attribute-list.fortran'
+        'begin': '\\G(?=\\s*(,|::))'
+        'end': '(::)|(?=[;!\\n])'
+        'endCaptures':
+          '1': 'name': 'keyword.operator.double-colon.fortran'
+        'patterns': [
+          {
+            'begin': '(,)'
+            'beginCaptures':
+              '1': 'name': 'punctuation.comma.fortran'
+            'end': '(?=::|[,;!\\n])'
+            'patterns':[
+              {'include': '#access-attribute'}
+              {'include': '#abstract-attribute'}
+              {'include': '#language-binding-attribute'}
+              {'include': '#extends-attribute'}
+              {'include': '#invalid-word'}
+            ]
+          }
+        ]
+      }
+      {# body
+        'begin': '(?i)\\s*\\b([a-z]\\w*)\\b'
+        'beginCaptures':
+          '1': 'name': 'entity.name.derived-type.fortran'
+        'end': '(?i)\\s*(end\\s*type)(?:\\s+(?:(\\1)|(\\w+)))?\\b'
+        #'end': '(?i)(?:^|(?<=;))\\s*(end\\s*type)(?:\\s+(?:(\\1)|(\\w+)))?\\b'
+        'endCaptures':
+          '1': 'name': 'keyword.control.endtype.fortran'
+          '2': 'name': 'entity.name.derived-type.fortran'
+          '3': 'name': 'invalid.error.fortran'
+        'patterns':[
+          {'include': '#dummy-variable-list'}
+          {
+            'comment': 'Derived type specification block.'
+            'name': 'meta.block.specification.fortran'
+            'begin': '(?i)(?!\\s*\\b(?:contains|end\\s*type)\\b)'
+            'end': '(?i)(?=\\s*\\b(?:contains|end\\s*type)\\b)'
+            #'begin': '(?i)^(?!\\s*\\b(?:contains|end\\s*type)\\b)'
+            #'end': '(?i)^(?=\\s*\\b(?:contains|end\\s*type)\\b)'
+            'patterns':[
+              {'include': '#comments'}
+              {'include': '#derived-type-component-attribute-specification'}
+              {'include': '#derived-type-component-parameter-specification'}
+              {'include': '#derived-type-component-procedure-specification'}
+              {'include': '#derived-type-component-type-specification'}
+            ]
+          }
+          {# contains section
+            'comment': 'Derived type contains block.'
+            'name': 'meta.block.contains.fortran'
+            'begin': '(?i)\\b(contains)\\b'
+            'beginCaptures':
+              '1': 'name': 'keyword.control.contains.fortran'
+            'end': '(?i)(?=\\s*end\\s*type\\b)'
+            'patterns':[
+              {'include': '#comments'}
+              {'include': '#derived-type-contains-attribute-specification'}
+              {'include': '#derived-type-contains-final-procedure-specification'}
+              {'include': '#derived-type-contains-generic-procedure-specification'}
+              {'include': '#derived-type-contains-procedure-specification'}
+            ]
+          }
+        ]
+      }
+    ]
+}


### PR DESCRIPTION
Fixes #4 

This isn't an ideal fix due to the fact it can allow for illegal highlighting inside the `TYPE` block but I think it is the only viable solution. 

A tree-sitter grammar for gcov may be a working solution since one for C already exists (and hopefully I'll get one working for Fortran). I think the only change I'd need to make to the existing tree-sitter C grammar would be to add the GCOV markup prefixed to the beginning of every line as an extra. I *think* it would then get ignored just like whitespace. However, since I can't use the "^" meta character in tree sitter grammars it is possible an external scanner would be needed to flag the start and end of the GCOV markup.